### PR TITLE
Fix GIF typo and add both hard and soft pronunciations

### DIFF
--- a/docs/sounds/g_j.md
+++ b/docs/sounds/g_j.md
@@ -50,7 +50,7 @@ The left side J and soft G sounds are formed on the left hand with `SKWR`.
 * `SKWROPB`: John
 * `SKWRABG`: jack
 * `SKWREUPL`: gym
-* `SKWREUF`: gif
+* `SKWREU*F`,`TKPWEU*F`: GIF
 
 ## Right side J
 


### PR DESCRIPTION
In the default Plover dictionary, `SKWREUF` prints "SKWREUF" as-is. `*` is needed to print out "GIF" in all capitals (there doesn't seem to be a dictionary entry for "gif" in lowercase).

Also, just for clarity, and because the pronunciation of "GIF" can be somewhat controversial, I'm also proposing adding the hard G version as well, since there is a Plover dictionary entry for it.