### PR TITLE
Fix good night entry

### DIFF
--- a/docs/sounds/g_j.md
+++ b/docs/sounds/g_j.md
@@ -78,7 +78,7 @@ On some hardware, pressing this many keys might be difficult. Make sure you aren
 | TR, T-R     | interest    |                                                                       |
 | TRG, T-RG   | interesting |                                                                       |
 | TKPW-B      | goodbye     |                                                                       |
-| TKPW-PBT    | goodnight   |                                                                       |
+| TKPWAOPBT   | good night  |                                                                       |
 | H-L         | hello       |                                                                       |
 | TKPWEPB     | again       |                                                                       |
 | TKPWEPBS    | against     |                                                                       |


### PR DESCRIPTION
`TKPW-PBT` prints as-is in the default Plover dictionary. The entry for "good night" with a space is `TKPWAOPBT`, which is what I'm proposing since it can probably be classified as a brief in this context, versus the entry for "goodnight" as one word, which would require two chords: `"TKPWAOD/TPHAOEUT"`.