### PR TITLE
Remove hello brief

### DIFF
--- a/docs/sounds/g_j.md
+++ b/docs/sounds/g_j.md
@@ -79,7 +79,6 @@ On some hardware, pressing this many keys might be difficult. Make sure you aren
 | TRG, T-RG   | interesting |                                                                       |
 | TKPW-B      | goodbye     |                                                                       |
 | TKPW-PBT    | goodnight   |                                                                       |
-| H-L         | hello       |                                                                       |
 | TKPWEPB     | again       |                                                                       |
 | TKPWEPBS    | against     |                                                                       |
 | TKPWEUPB    | begin       |                                                                       |


### PR DESCRIPTION
`H-L` is not a registered brief in the default Plover dictionary for "hello", but rather for "historical". The only entries for "hello" are `HEL/HRO` and `HEL/HROE`, so I'm proposing just removing it from this section to avoid confusion.