### PR TITLE
g_j: update "GIF" to reflect 4.0.0 dictionary

### DIFF
--- a/docs/sounds/g_j.md
+++ b/docs/sounds/g_j.md
@@ -18,6 +18,7 @@ The hard G sound is formed on the left hand with `TKPW`.
 * `TKPWAEUT`: gait
 * `TKPWOUT`: gout
 * `TKPWRAEUD`: grade
+* `TKPW*EUF`: GIF
 
 ## Right side G as -ing
 
@@ -50,7 +51,7 @@ The left side J and soft G sounds are formed on the left hand with `SKWR`.
 * `SKWROPB`: John
 * `SKWRABG`: jack
 * `SKWREUPL`: gym
-* `SKWREUF`: gif
+* `SKWR*EUF`: GIF
 
 ## Right side J
 


### PR DESCRIPTION
It appears that plover now has two unique chords for GIF (probably to account for the different pronunciations). Either way, the original doesn't appear to exist in the latest main.json