### PR TITLE
Remove 'cash' from sentence & remove 'nowhere' from Both sides N

### DIFF
--- a/docs/sounds/n.md
+++ b/docs/sounds/n.md
@@ -86,7 +86,7 @@ Find steno outlines that will write these English sentences, including punctuati
 
 1. He is a boy-man, in my opinion.
 2. I can't say what we should do or not, nothing is up to me in this case.
-3. On what condition would you continue to watch Bart? Do you want cash?
+3. On what condition would you continue to watch Bart? What do you want from us?
 4. Come on, take any of them, and we will head out. If you do not make a choice we will leave with nothing at all.
 5. I said you had a choice and you did not make it before we had to leave. I stated the condition and you failed to pick in a minute so you had to leave with nothing. This is not new or anything.
 6. What reason would you do that for?

--- a/docs/sounds/n.md
+++ b/docs/sounds/n.md
@@ -52,7 +52,6 @@ There are a lot of briefs that use Ns. This is not an extensive list.
 | TPHU   | new         |                                                                      |
 | TPHEU  | any         |                                                                      |
 | TPHOG  | nothing     |                                                                      |
-| TPH-R  | nowhere     |                                                                      |
 | TPH-B  | nobody      |                                                                      |
 | TPH-L  | until       |                                                                      |
 | S-PB   | season      |                                                                      |
@@ -74,7 +73,7 @@ Write the English sentence represented by these outlines, including punctuation.
 2. `TPH-L SHE HREFS EU HR TPHOT TPHOD OF TP-BG`
 3. `WHA S HER P-PB OPB TH KW-PL`
 4. `SHE HR TKO T KW-BG PWUT OPB WUPB K-PB STPH-FPLT TPH-B K WAFP HER TP-PL`
-5. `PWART WAS TPH-R TO -B TPOUPBD TP-PL`
+5. `PWART HEUD TPH-PB -T KOUFP TP-R SO HROPBG TP-PL`
 6. `S-PB WUPB S TKOPB TP-PL HR U T-PB TO WAFP TH TPH-L TPHOG S HREFT H-F`
 7. `S T TPH PHEUPBT K-PB KW-BG AS TPH TPHU KW-BG OR S T TPHU H-PB TPHU KW-PL`
 8. `STABG UP -T HROGS SKP AD SOPL TPHRAEUPL TPH-PB THEPL SKP U SHO -B WARPL TPH AEU PHEUPB TP-PL`


### PR DESCRIPTION
In Plover's newest `main.json`, the brief for `nowhere` is `TPHO*ER` and not `TPH-R` Because this brief contains `OE` which isn't introduced at this point in the textbook it would be in the best interest to remove `nowhere`. I did my best to come up with a replacement sentence that continues the "plot" with the third outline finding practice, which I altered because it used `cash`, and right side `sh` isn't introduced at this point in the textbook