### PR TITLE
Remove duplicate example and 'like' from Both sides G and J

### DIFF
--- a/docs/sounds/g_j.md
+++ b/docs/sounds/g_j.md
@@ -64,7 +64,6 @@ The Right side J and soft G sounds are formed on the right hand with `PBLG`.
 - `SKWRORPBLG`: George
 - `TKPWORPBLG`: gorge
 - `TKPWAEUPBLG`: gauge
-- `TKPWRUPBLG`: grudge
 
 On some hardware, pressing this many keys might be difficult. Make sure you aren't trying to just use your fingers, your forearms should be the main source of power. Better steno hardware will also require less force.
 

--- a/docs/sounds/g_j.md
+++ b/docs/sounds/g_j.md
@@ -115,4 +115,4 @@ Find steno outlines that will write these English sentences, including punctuati
 14. I am going to the gym to get gains. I go almost every day.
 15. Do not judge the gorge by how far down it goes, it is dangerous.
 16. When technology knows language as well as we do, we are in danger.
-17. Do you say gif like girl or jar?
+17. Do you say gif similar to girl or jar?


### PR DESCRIPTION
Removed duplicate instance of `Grudge` as an example for Right side J/soft G

Outline 17 uses 'Like' which has `AOEU` as the `eye` vowel, which is introduced later in the textbook. Replaced with 'Similar to.'