### PR TITLE
Correct stroke for "gouge"

### DIFF
--- a/docs/sounds/g_j.md
+++ b/docs/sounds/g_j.md
@@ -64,7 +64,7 @@ The Right side J and soft G sounds are formed on the right hand with `PBLG`.
 - `SKWRORPBLG`: George
 - `TKPWORPBLG`: gorge
 - `TKPWAEUPBLG`: gauge
-- `TKPWROUPBLG`: gouge
+- `TKPWOUPBLG`: gouge
 
 On some hardware, pressing this many keys might be difficult. Make sure you aren't trying to just use your fingers, your forearms should be the main source of power. Better steno hardware will also require less force.
 


### PR DESCRIPTION
There should be no R- here.