### PR TITLE
Correct usage of ‹spelling instead of phonetics› tag.

### DIFF
--- a/docs/sounds/i.md
+++ b/docs/sounds/i.md
@@ -27,10 +27,10 @@ This is the lax version of "i", as found in:
 | :---- | :---------- | :---------------------------- |
 | EU    | I           | Always capitalized            |
 | HEU   | hi          | Spelling instead of phonetics |
-| HEUS  | his         | Spelling instead of phonetics |
+| HEUS  | his         |                               |
 | WEU   | which       |                               |
 | PWEU  | by          | Spelling instead of phonetics |
-| WREU  | write       |                               |
+| WREU  | write       | Spelling instead of phonetics |
 | THEU  | think       |                               |
 | HREUF | live        |                               |
 | HREUL | little      |                               |


### PR DESCRIPTION
The word `HEUS` has the same `EU` /ɪ/ vowel as in ‹his›, but the word `WREU`, ‹write›, does not have that vowel. Move the ‹spelling instead of phonetics› comment from `HEUS` to `WREU`.