### PR TITLE
Update basic-number-bar.md Fixing typo, an unknown chord …

### DIFF
--- a/docs/layout/basic-number-bar.md
+++ b/docs/layout/basic-number-bar.md
@@ -44,7 +44,7 @@ Now we can write complex numbers like "602208" in just two strokes: `#TOEUF #TOL
 Write the English sentence represented by these outlines, including punctuation.
 
 1. `E H #TO OR SO TP-PL`
-2. `-F -T #SAO E KEPT #AEUP KW-PL OR HAF TP-PL`
+2. `-F -T #SAO E KEPT #AEUP KW-BG OR HAF TP-PL`
 3. `WHA R -T #ST STEPS H-F`
 
 ### 2. Find outlines


### PR DESCRIPTION
…KW-PL.

Nowhere before or during this lesson has the author introduced to the beginner reader the chord KW-PL. What has been introduced are TP-PL for the period punctuation {.} and KW-BG for the comma punctuation {,}. I assume this was a typo from the author and these two chords got mashed together. I think what was meant was KW-BG. Using my own steno keyboard, the uni, and plover's complete default layout and dictionaries KW-PL comes out as a question mark {?} which--up to this point-- the reader has learned is the chord H-F for {?}.