### PR TITLE
Update n.md-Conflict in default dictionary?

### DIFF
--- a/docs/sounds/n.md
+++ b/docs/sounds/n.md
@@ -52,7 +52,7 @@ There are a lot of briefs that use Ns. This is not an extensive list.
 | TPHU   | new         |                                                                      |
 | TPHEU  | any         |                                                                      |
 | TPHOG  | nothing     |                                                                      |
-| TPH-R  | nowhere     |                                                                      |
+| TPH-R  | nowhere     | (it may be necessary to manually change one's dictionary to this.)   |
 | TPH-B  | nobody      |                                                                      |
 | TPH-L  | until       |                                                                      |
 | S-PB   | season      |                                                                      |


### PR DESCRIPTION
My default plover dictionary had TPH-R set to "nor." I added a precaution to the user who may be installing Plover for the first time that they're not guaranteed this brief and it may be necessary to change their dictionary to correspond with the book.